### PR TITLE
Agrego validación de phone para que empiece con "54"

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -23,6 +23,8 @@ def validate_client(data):
     if phone == "":
         errors["phone"] = "Por favor ingrese un teléfono"
     elif not re.match(pattern_phone, phone):
+        raise ValidationError("El formato del teléfono es inválido.")
+    elif not re.match(pattern_phone, phone):
         errors["phone"] = "El número de teléfono debe comenzar con el prefijo '54' para Argentina."
 
     if email == "":
@@ -405,6 +407,8 @@ def validate_vet(data):
         errors["email"] = "Por favor ingrese un email valido"
     if phone == "":
         errors["phone"] = "Por favor ingrese un teléfono"
+    elif not re.match(pattern_phone, phone):
+        raise ValidationError("El formato del teléfono es inválido.")
     elif not re.match(pattern_phone, phone):
         errors["phone"] = "El número de teléfono debe comenzar con el prefijo '54' para Argentina."
 

--- a/app/models.py
+++ b/app/models.py
@@ -14,7 +14,7 @@ def validate_client(data):
     name = data.get("name", "")
     phone = data.get("phone", "")
     email = data.get("email", "")
-    pattern_phone = r'^\+?[\d\s\-\(\)]+$'
+    pattern_phone = r'^54[\d\s\-\(\)]+$'
 
     if name == "":
         errors["name"] = "Por favor ingrese un nombre"
@@ -22,7 +22,7 @@ def validate_client(data):
     if phone == "":
         errors["phone"] = "Por favor ingrese un teléfono"
     elif not re.match(pattern_phone, phone):
-        raise ValidationError("El formato del teléfono es inválido.")
+        errors["phone"] = "El número de teléfono debe comenzar con el prefijo '54' para Argentina."
 
     if email == "":
         errors["email"] = "Por favor ingrese un email"

--- a/app/models.py
+++ b/app/models.py
@@ -23,8 +23,7 @@ def validate_client(data):
     if phone == "":
         errors["phone"] = "Por favor ingrese un teléfono"
     elif not re.match(pattern_phone, phone):
-        errors["phone"] = "El número de teléfono debe comenzar con el prefijo '54' para Argentina."
-
+        errors["phone"] = "El número de teléfono debe comenzar con el prefijo 54 para Argentina."
     if email == "":
         errors["email"] = "Por favor ingrese un email"
     elif email.count("@") == 0:
@@ -406,7 +405,7 @@ def validate_vet(data):
     if phone == "":
         errors["phone"] = "Por favor ingrese un teléfono"        
     elif not re.match(pattern_phone, phone):
-        errors["phone"] = "El número de teléfono debe comenzar con el prefijo '54' para Argentina."
+        errors["phone"] = "El número de teléfono debe comenzar con el prefijo 54 para Argentina."
 
 
     return errors

--- a/app/models.py
+++ b/app/models.py
@@ -3,7 +3,6 @@ import re
 from datetime import date
 
 #Importaciones de Django
-from django.core.exceptions import ValidationError
 from django.db import models
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -377,7 +377,7 @@ def validate_vet(data):
     name = data.get("name", "")
     email = data.get("email", "")
     phone = data.get("phone", "")
-    pattern_phone = r'^\+?[\d\s\-\(\)]+$'
+    pattern_phone = r'^54[\d\s\-\(\)]+$'
 
     if name == "":
         errors["name"] = "Por favor ingrese un nombre"
@@ -389,7 +389,7 @@ def validate_vet(data):
     if phone == "":
         errors["phone"] = "Por favor ingrese un teléfono"
     elif not re.match(pattern_phone, phone):
-        raise ValidationError("El formato del teléfono es inválido.")
+        errors["phone"] = "El número de teléfono debe comenzar con el prefijo '54' para Argentina."
 
     return errors
 

--- a/app/models.py
+++ b/app/models.py
@@ -406,7 +406,7 @@ def validate_vet(data):
     if phone == "":
         errors["phone"] = "Por favor ingrese un teléfono"        
     elif not re.match(pattern_phone, phone):
-        raise ValidationError("El número de teléfono debe comenzar con el prefijo '54' para Argentina.")
+        errors["phone"] = "El número de teléfono debe comenzar con el prefijo '54' para Argentina."
 
 
     return errors

--- a/app/models.py
+++ b/app/models.py
@@ -23,8 +23,6 @@ def validate_client(data):
     if phone == "":
         errors["phone"] = "Por favor ingrese un teléfono"
     elif not re.match(pattern_phone, phone):
-        raise ValidationError("El formato del teléfono es inválido.")
-    elif not re.match(pattern_phone, phone):
         errors["phone"] = "El número de teléfono debe comenzar con el prefijo '54' para Argentina."
 
     if email == "":
@@ -406,11 +404,10 @@ def validate_vet(data):
     elif email.count("@") == 0:
         errors["email"] = "Por favor ingrese un email valido"
     if phone == "":
-        errors["phone"] = "Por favor ingrese un teléfono"
+        errors["phone"] = "Por favor ingrese un teléfono"        
     elif not re.match(pattern_phone, phone):
-        raise ValidationError("El formato del teléfono es inválido.")
-    elif not re.match(pattern_phone, phone):
-        errors["phone"] = "El número de teléfono debe comenzar con el prefijo '54' para Argentina."
+        raise ValidationError("El número de teléfono debe comenzar con el prefijo '54' para Argentina.")
+
 
     return errors
 

--- a/app/templates/clients/form.html
+++ b/app/templates/clients/form.html
@@ -26,7 +26,7 @@
                         id="name"
                         name="name"
                         value="{{client.name}}"
-                        class="form-control"
+                        class="form-control {% if errors.name %}is-invalid{% endif %}"
                         required/>
 
                     {% if errors.name %}
@@ -40,7 +40,7 @@
                     <input type="text"
                         id="phone"
                         name="phone"
-                        class="form-control"
+                        class="form-control {% if errors.phone %}is-invalid{% endif %}"
                         value="{{client.phone}}"
                         required/>
 
@@ -55,7 +55,7 @@
                     <input type="email"
                         id="email"
                         name="email"
-                        class="form-control"
+                        class="form-control {% if errors.email %}is-invalid{% endif %}"
                         value="{{ client.email }}"
                         required/>
 
@@ -71,7 +71,7 @@
                         id="address"
                         name="address"
                         value="{{client.address}}"
-                        class="form-control" />
+                        class="form-control {% if errors.address %}is-invalid{% endif %}" />
 
                     <div class="invalid-feedback">
                         La dirrección es opcional

--- a/app/templates/vets/form.html
+++ b/app/templates/vets/form.html
@@ -26,7 +26,7 @@
                         id="name"
                         name="name"
                         value="{{vet.name}}"
-                        class="form-control"
+                        class="form-control {% if errors.name %}is-invalid{% endif %}"
                         required/>
 
                     {% if errors.name %}
@@ -40,7 +40,7 @@
                     <input type="email"
                         id="email"
                         name="email"
-                        class="form-control"
+                        class="form-control {% if errors.email %}is-invalid{% endif %}"
                         value="{{ vet.email }}"
                         required/>
 
@@ -55,7 +55,7 @@
                     <input type="number"
                         id="phone"
                         name="phone"
-                        class="form-control"
+                        class="form-control {% if errors.phone %}is-invalid{% endif %}"
                         value="{{ vet.phone }}"
                         required/>
 

--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -119,6 +119,18 @@ class ClientsTest(TestCase):
             },
         )
         self.assertContains(response, "Por favor ingrese un teléfono")
+    
+    def test_validation_invalid_phone_number(self):
+        response = self.client.post(
+            reverse("clients_form"),
+            data={
+                "name": "Juan Sebastian Veron",
+                "phone": "111111111",
+                "email": "brujita75@vetsoft.com",
+                "address": "13 y 44",     
+            },
+        )
+        self.assertContains(response, "El número de teléfono debe comenzar con el prefijo 54 para Argentina.")
 
 class ProvidersTest(TestCase):
 

--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -310,8 +310,19 @@ class VetsTest(TestCase):
                 "name": "Juan Perez",
                 "phone": "",  # teléfono inválido
                 "email": "hola@vetsoft.com",
-                "address": "Calle 123",
             },
         )
 
         self.assertContains(response, "Por favor ingrese un teléfono")
+
+    def test_validation_invalid_phone_number(self):
+        response = self.client.post(
+            reverse("vets_form"),
+            data={
+                "name": "Juan Sebastian Veron",
+                "phone": "111111111",
+                "email": "brujita75@vetsoft.com",  
+            },
+        )
+        self.assertContains(response, "El número de teléfono debe comenzar con el prefijo 54 para Argentina.")
+

--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -28,7 +28,7 @@ class ClientsTest(TestCase):
             reverse("clients_form"),
             data={
                 "name": "Juan Sebastian Veron",
-                "phone": "221555232",
+                "phone": "54221555232",
                 "address": "13 y 44",
                 "email": "brujita75@vetsoft.com",
             },
@@ -37,7 +37,7 @@ class ClientsTest(TestCase):
         self.assertEqual(len(clients), 1)
 
         self.assertEqual(clients[0].name, "Juan Sebastian Veron")
-        self.assertEqual(clients[0].phone, "221555232")
+        self.assertEqual(clients[0].phone, "54221555232")
         self.assertEqual(clients[0].address, "13 y 44")
         self.assertEqual(clients[0].email, "brujita75@vetsoft.com")
 
@@ -62,7 +62,7 @@ class ClientsTest(TestCase):
             reverse("clients_form"),
             data={
                 "name": "Juan Sebastian Veron",
-                "phone": "221555232",
+                "phone": "54221555232",
                 "address": "13 y 44",
                 "email": "brujita75",
             },
@@ -75,7 +75,7 @@ class ClientsTest(TestCase):
             reverse("clients_form"),
             data={
                 "name": "Rosario Central",
-                "phone": "4444444",
+                "phone": "544444444",
                 "address": "13 y 44",
                 "email": "rositac@gmail.com",
             },
@@ -87,7 +87,7 @@ class ClientsTest(TestCase):
         client = Client.objects.create(
             name="Juan Sebastián Veron",
             address="13 y 44",
-            phone="221555232",
+            phone="54221555232",
             email="brujita75@vetsoft.com",
         )
 

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -317,12 +317,13 @@ class VetModelTest(TestCase):
     def test_validate_phone_number_in_phone_field(self):
         vet_data = {
             "name": "Juan Sebastian Veron",
-            "phone": "Hola, no soy un teléfono válido",
+            "phone": "",
             "address": "13 y 44",
             "email": "brujita75@vetsoft.com",
         }
         
-        with self.assertRaises(ValidationError):
-            validate_vet(vet_data)
+        errors = validate_client(vet_data)
+        self.assertIn("phone", errors)
+        self.assertEqual(errors["phone"], "Por favor ingrese un teléfono")
         
 

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -82,7 +82,7 @@ class ClientModelTest(TestCase):
         }
         errors = validate_client(client_data)
         self.assertIn("phone", errors)
-        self.assertEqual(errors["phone"], "El número de teléfono debe comenzar con el prefijo '54' para Argentina.")
+        self.assertEqual(errors["phone"], "El número de teléfono debe comenzar con el prefijo 54 para Argentina.")
 
         
 
@@ -335,7 +335,7 @@ class VetModelTest(TestCase):
         }
         errors = validate_vet(vet_data)
         self.assertIn("phone", errors)
-        self.assertEqual(errors["phone"], "El número de teléfono debe comenzar con el prefijo '54' para Argentina.")
+        self.assertEqual(errors["phone"], "El número de teléfono debe comenzar con el prefijo 54 para Argentina.")
 
         
 

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -72,6 +72,17 @@ class ClientModelTest(TestCase):
         errors = validate_client(client_data)
         self.assertIn("phone", errors)
         self.assertEqual(errors["phone"], "Por favor ingrese un teléfono")
+    
+    def test_phone_number_without_54(self):
+        client_data = {
+            "name": "Juan Sebastian Veron",
+            "phone": "2245556789",
+            "address": "13 y 44",
+            "email": "brujita75@vetsoft.com",
+        }
+        errors = validate_client(client_data)
+        self.assertIn("phone", errors)
+        self.assertEqual(errors["phone"], "El número de teléfono debe comenzar con el prefijo '54' para Argentina.")
 
         
 

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -27,46 +27,46 @@ class ClientModelTest(TestCase):
         Client.save_client(
             {
                 "name": "Juan Sebastian Veron",
-                "phone": "221555232",
+                "phone": "54221555232",
                 "address": "13 y 44",
                 "email": "brujita75@vetsoft.com",
             },
         )
         client = Client.objects.get(pk=1)
 
-        self.assertEqual(client.phone, "221555232")
+        self.assertEqual(client.phone, "54221555232")
 
-        client.update_client({"phone": "221555233"})
+        client.update_client({"phone": "54221555233"})
 
         client_updated = Client.objects.get(pk=1)
 
-        self.assertEqual(client_updated.phone, "221555233")
+        self.assertEqual(client_updated.phone, "54221555233")
 
     def test_update_client_with_error(self):
         Client.save_client(
             {
                 "name": "Juan Sebastian Veron",
-                "phone": "221555232",
+                "phone": "54221555232",
                 "address": "13 y 44",
                 "email": "brujita75@vetsoft.com",
             },
         )
         client = Client.objects.get(pk=1)
 
-        self.assertEqual(client.phone, "221555232")
+        self.assertEqual(client.phone, "54221555232")
 
         client.update_client({"phone": ""})
 
         client_updated = Client.objects.get(pk=1)
 
-        self.assertEqual(client_updated.phone, "221555232")
+        self.assertEqual(client_updated.phone, "54221555232")
     
     def test_validate_phone_number_in_phone_field(self):
         client_data = {
             "name": "Juan Sebastian Veron",
             "phone": "Hola, no soy un teléfono válido",
             "address": "13 y 44",
-            "email": "brujita75@hotmail.com",
+            "email": "brujita75@vetsoft.com",
         }
         
         with self.assertRaises(ValidationError):

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -325,5 +325,17 @@ class VetModelTest(TestCase):
         errors = validate_client(vet_data)
         self.assertIn("phone", errors)
         self.assertEqual(errors["phone"], "Por favor ingrese un teléfono")
+    
+    def test_phone_number_without_54(self):
+        vet_data = {
+            "name": "Juan Sebastian Veron",
+            "phone": "2245556789",
+            "address": "13 y 44",
+            "email": "brujita75@vetsoft.com",
+        }
+        errors = validate_vet(vet_data)
+        self.assertIn("phone", errors)
+        self.assertEqual(errors["phone"], "El número de teléfono debe comenzar con el prefijo '54' para Argentina.")
+
         
 

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -64,13 +64,15 @@ class ClientModelTest(TestCase):
     def test_validate_phone_number_in_phone_field(self):
         client_data = {
             "name": "Juan Sebastian Veron",
-            "phone": "Hola, no soy un teléfono válido",
+            "phone": "",
             "address": "13 y 44",
             "email": "brujita75@vetsoft.com",
         }
         
-        with self.assertRaises(ValidationError):
-            validate_client(client_data)
+        errors = validate_client(client_data)
+        self.assertIn("phone", errors)
+        self.assertEqual(errors["phone"], "Por favor ingrese un teléfono")
+
         
 
 class ProviderModelTest(TestCase):

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -72,14 +72,14 @@ class ClientsRepoTestCase(PlaywrightTestCase):
         Client.objects.create(
             name="Juan Sebastián Veron",
             address="13 y 44",
-            phone="221555232",
+            phone="54221555232",
             email="brujita75@vetsoft.com",
         )
 
         Client.objects.create(
             name="Guido Carrillo",
             address="1 y 57",
-            phone="221232555",
+            phone="54221232555",
             email="goleador@vetsoft.com",
         )
 
@@ -89,12 +89,12 @@ class ClientsRepoTestCase(PlaywrightTestCase):
 
         expect(self.page.get_by_text("Juan Sebastián Veron")).to_be_visible()
         expect(self.page.get_by_text("13 y 44")).to_be_visible()
-        expect(self.page.get_by_text("221555232")).to_be_visible()
+        expect(self.page.get_by_text("54221555232")).to_be_visible()
         expect(self.page.get_by_text("brujita75@vetsoft.com")).to_be_visible()
 
         expect(self.page.get_by_text("Guido Carrillo")).to_be_visible()
         expect(self.page.get_by_text("1 y 57")).to_be_visible()
-        expect(self.page.get_by_text("221232555")).to_be_visible()
+        expect(self.page.get_by_text("54221232555")).to_be_visible()
         expect(self.page.get_by_text("goleador@vetsoft.com")).to_be_visible()
 
     def test_should_show_add_client_action(self):
@@ -109,7 +109,7 @@ class ClientsRepoTestCase(PlaywrightTestCase):
         client = Client.objects.create(
             name="Juan Sebastián Veron",
             address="13 y 44",
-            phone="221555232",
+            phone="54221555232",
             email="brujita75@vetsoft.com",
         )
 
@@ -124,7 +124,7 @@ class ClientsRepoTestCase(PlaywrightTestCase):
         client = Client.objects.create(
             name="Juan Sebastián Veron",
             address="13 y 44",
-            phone="221555232",
+            phone="54221555232",
             email="brujita75@vetsoft.com",
         )
 
@@ -145,7 +145,7 @@ class ClientsRepoTestCase(PlaywrightTestCase):
         Client.objects.create(
             name="Juan Sebastián Veron",
             address="13 y 44",
-            phone="221555232",
+            phone="54221555232",
             email="brujita75@vetsoft.com",
         )
 
@@ -172,14 +172,14 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         expect(self.page.get_by_role("form")).to_be_visible()
 
         self.page.get_by_label("Nombre").fill("Juan Sebastián Veron")
-        self.page.get_by_label("Teléfono").fill("221555232")
+        self.page.get_by_label("Teléfono").fill("54221555232")
         self.page.get_by_label("Email").fill("brujita75@vetsoft.com")
         self.page.get_by_label("Dirección").fill("13 y 44")
 
         self.page.get_by_role("button", name="Guardar").click()
 
         expect(self.page.get_by_text("Juan Sebastián Veron")).to_be_visible()
-        expect(self.page.get_by_text("221555232")).to_be_visible()
+        expect(self.page.get_by_text("54221555232")).to_be_visible()
         expect(self.page.get_by_text("brujita75@vetsoft.com")).to_be_visible()
         expect(self.page.get_by_text("13 y 44")).to_be_visible()
 
@@ -195,7 +195,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         expect(self.page.get_by_text("Por favor ingrese un email")).to_be_visible()
 
         self.page.get_by_label("Nombre").fill("Juan Sebastián Veron")
-        self.page.get_by_label("Teléfono").fill("221555232")
+        self.page.get_by_label("Teléfono").fill("54221555232")
         self.page.get_by_label("Email").fill("brujita75")
         self.page.get_by_label("Dirección").fill("13 y 44")
 
@@ -240,7 +240,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         client = Client.objects.create(
             name="Juan Sebastián Veron",
             address="13 y 44",
-            phone="221555232",
+            phone="54221555232",
             email="brujita75@vetsoft.com",
         )
 
@@ -248,7 +248,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         self.page.goto(f"{self.live_server_url}{path}")
 
         self.page.get_by_label("Nombre").fill("Guido Carrillo")
-        self.page.get_by_label("Teléfono").fill("221232555")
+        self.page.get_by_label("Teléfono").fill("54221232555")
         self.page.get_by_label("Email").fill("goleador@vetsoft.com")
         self.page.get_by_label("Dirección").fill("1 y 57")
 
@@ -256,12 +256,12 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
 
         expect(self.page.get_by_text("Juan Sebastián Veron")).not_to_be_visible()
         expect(self.page.get_by_text("13 y 44")).not_to_be_visible()
-        expect(self.page.get_by_text("221555232")).not_to_be_visible()
+        expect(self.page.get_by_text("54221555232")).not_to_be_visible()
         expect(self.page.get_by_text("brujita75@vetsoft.com")).not_to_be_visible()
 
         expect(self.page.get_by_text("Guido Carrillo")).to_be_visible()
         expect(self.page.get_by_text("1 y 57")).to_be_visible()
-        expect(self.page.get_by_text("221232555")).to_be_visible()
+        expect(self.page.get_by_text("54221232555")).to_be_visible()
         expect(self.page.get_by_text("goleador@vetsoft.com")).to_be_visible()
 
         edit_action = self.page.get_by_role("link", name="Editar")


### PR DESCRIPTION
# Descripción del PR
- Agrego validación para que el phone del cliente y del veterinario siempre empiecen con "54" y agrego test de integración y test unitario 

# Lista de Cambios
- Agrego validación para el formato correcto del número de télefono
- Modifico los test existentes para que coincida con el formato correcto del número de télefono
- Agrego test de integración y test unitario específicos para verificar que siempre comience con "54" en Cliente y en Veterinario