### PR TITLE
Agrego mensaje de error en el input de teléfono de Cliente

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -428,9 +428,9 @@ def validate_vet(data):
     elif email.count("@") == 0:
         errors["email"] = "Por favor ingrese un email valido"
     if phone == "":
-        errors["phone"] = "Por favor ingrese un teléfono que solo contenga números"       
+        errors["phone"] = "Por favor ingrese un teléfono"       
     elif not re.match(pattern_phone, phone):
-        errors["phone"] = "El número de teléfono debe comenzar con el prefijo 54 para Argentina y solo puede contener números"
+        errors["phone"] = "El número de teléfono debe comenzar con el prefijo 54 para Argentina"
 
 
     return errors

--- a/app/models.py
+++ b/app/models.py
@@ -22,7 +22,7 @@ def validate_client(data):
     elif not re.match(pattern_name, name):
         errors["name"] = "El nombre solo puede contener letras y espacios"
     if phone == "":
-        errors["phone"] = "Por favor ingrese un teléfono"
+        errors["phone"] = "Por favor ingrese un teléfono que solo contenga números"
     elif not re.match(pattern_phone, phone):
         errors["phone"] = "El número de teléfono debe comenzar con el prefijo 54 para Argentina y solo puede contener números"
     if email == "":
@@ -425,9 +425,9 @@ def validate_vet(data):
     elif email.count("@") == 0:
         errors["email"] = "Por favor ingrese un email valido"
     if phone == "":
-        errors["phone"] = "Por favor ingrese un teléfono"        
+        errors["phone"] = "Por favor ingrese un teléfono que solo contenga números"       
     elif not re.match(pattern_phone, phone):
-        errors["phone"] = "El número de teléfono debe comenzar con el prefijo 54 para Argentina."
+        errors["phone"] = "El número de teléfono debe comenzar con el prefijo 54 para Argentina y solo puede contener números"
 
 
     return errors

--- a/app/models.py
+++ b/app/models.py
@@ -13,6 +13,7 @@ def validate_client(data):
     name = data.get("name", "")
     phone = data.get("phone", "")
     email = data.get("email", "")
+    pattern_phone_prefix = r'^54'
     pattern_phone = r'^54[\d\s\-\(\)]+$'
     pattern_email = r'^[a-zA-Z0-9_.+-]+@vetsoft.com$'
     pattern_name = r'^[a-zA-Z\s]+$' #solo letras y espacios
@@ -22,7 +23,9 @@ def validate_client(data):
     elif not re.match(pattern_name, name):
         errors["name"] = "El nombre solo puede contener letras y espacios"
     if phone == "":
-        errors["phone"] = "Por favor ingrese un teléfono que solo contenga números"
+        errors["phone"] = "Por favor ingrese un teléfono"
+    elif not re.match(pattern_phone_prefix, phone):
+        errors["phone"] = "El número de teléfono debe comenzar con el prefijo 54 para Argentina"
     elif not re.match(pattern_phone, phone):
         errors["phone"] = "El número de teléfono debe comenzar con el prefijo 54 para Argentina y solo puede contener números"
     if email == "":

--- a/app/models.py
+++ b/app/models.py
@@ -24,7 +24,7 @@ def validate_client(data):
     if phone == "":
         errors["phone"] = "Por favor ingrese un teléfono"
     elif not re.match(pattern_phone, phone):
-        errors["phone"] = "El número de teléfono debe comenzar con el prefijo 54 para Argentina."
+        errors["phone"] = "El número de teléfono debe comenzar con el prefijo 54 para Argentina y solo puede contener números"
     if email == "":
         errors["email"] = "Por favor ingrese un email"
     elif email.count("@") == 0:

--- a/app/templates/clients/form.html
+++ b/app/templates/clients/form.html
@@ -37,7 +37,7 @@
                 </div>
                 <div>
                     <label for="phone" class="form-label">Teléfono</label>
-                    <input type="number"
+                    <input type="text"
                         id="phone"
                         name="phone"
                         class="form-control {% if errors.phone %}is-invalid{% endif %}"

--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -49,7 +49,7 @@ class ClientsTest(TestCase):
         )
 
         self.assertContains(response, "Por favor ingrese un nombre")
-        self.assertContains(response, "Por favor ingrese un teléfono que solo contenga números")
+        self.assertContains(response, "Por favor ingrese un teléfono")
         self.assertContains(response, "Por favor ingrese un email")
 
     def test_should_response_with_404_status_if_client_doesnt_exists(self):
@@ -117,7 +117,7 @@ class ClientsTest(TestCase):
                 "address": "Calle 123",
             },
         )
-        self.assertContains(response, "Por favor ingrese un teléfono que solo contenga números")
+        self.assertContains(response, "Por favor ingrese un teléfono")
     
     def test_validation_invalid_phone_number(self):
         response = self.client.post(
@@ -129,7 +129,7 @@ class ClientsTest(TestCase):
                 "address": "13 y 44",     
             },
         )
-        self.assertContains(response, "El número de teléfono debe comenzar con el prefijo 54 para Argentina.")
+        self.assertContains(response, "El número de teléfono debe comenzar con el prefijo 54 para Argentina")
     
     def test_validation_invalid_name(self):
         response = self.client.post(
@@ -342,7 +342,7 @@ class VetsTest(TestCase):
             },
         )
 
-        self.assertContains(response, "Por favor ingrese un teléfono que solo contenga números")
+        self.assertContains(response, "Por favor ingrese un teléfono")
 
     def test_validation_invalid_phone_number(self):
         response = self.client.post(
@@ -353,5 +353,5 @@ class VetsTest(TestCase):
                 "email": "brujita75@vetsoft.com",  
             },
         )
-        self.assertContains(response, "El número de teléfono debe comenzar con el prefijo 54 para Argentina.")
+        self.assertContains(response, "El número de teléfono debe comenzar con el prefijo 54 para Argentina")
 

--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -49,7 +49,7 @@ class ClientsTest(TestCase):
         )
 
         self.assertContains(response, "Por favor ingrese un nombre")
-        self.assertContains(response, "Por favor ingrese un teléfono")
+        self.assertContains(response, "Por favor ingrese un teléfono que solo contenga números")
         self.assertContains(response, "Por favor ingrese un email")
 
     def test_should_response_with_404_status_if_client_doesnt_exists(self):
@@ -117,7 +117,7 @@ class ClientsTest(TestCase):
                 "address": "Calle 123",
             },
         )
-        self.assertContains(response, "Por favor ingrese un teléfono")
+        self.assertContains(response, "Por favor ingrese un teléfono que solo contenga números")
     
     def test_validation_invalid_phone_number(self):
         response = self.client.post(
@@ -342,7 +342,7 @@ class VetsTest(TestCase):
             },
         )
 
-        self.assertContains(response, "Por favor ingrese un teléfono")
+        self.assertContains(response, "Por favor ingrese un teléfono que solo contenga números")
 
     def test_validation_invalid_phone_number(self):
         response = self.client.post(

--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -131,6 +131,18 @@ class ClientsTest(TestCase):
         )
         self.assertContains(response, "El número de teléfono debe comenzar con el prefijo 54 para Argentina")
     
+    def test_validation_invalid_format_phone_number(self):
+        response = self.client.post(
+            reverse("clients_form"),
+            data={
+                "name": "Juan Sebastian Veron",
+                "phone": "54aaa1111111",
+                "email": "brujita75@vetsoft.com",
+                "address": "13 y 44",     
+            },
+        )
+        self.assertContains(response, "El número de teléfono debe comenzar con el prefijo 54 para Argentina y solo puede contener números")
+    
     def test_validation_invalid_name(self):
         response = self.client.post(
             reverse("clients_form"),

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -70,7 +70,7 @@ class ClientModelTest(TestCase):
         
         errors = validate_client(client_data)
         self.assertIn("phone", errors)
-        self.assertEqual(errors["phone"], "Por favor ingrese un teléfono que solo contenga números")
+        self.assertEqual(errors["phone"], "Por favor ingrese un teléfono")
     
     def test_phone_number_without_54(self):
         client_data = {
@@ -81,7 +81,7 @@ class ClientModelTest(TestCase):
         }
         errors = validate_client(client_data)
         self.assertIn("phone", errors)
-        self.assertEqual(errors["phone"], "El número de teléfono debe comenzar con el prefijo 54 para Argentina.")
+        self.assertEqual(errors["phone"], "El número de teléfono debe comenzar con el prefijo 54 para Argentina")
     
     def test_validate_name_with_invalid_characters(self):
         client_data = {
@@ -423,7 +423,7 @@ class VetModelTest(TestCase):
         
         errors = validate_client(vet_data)
         self.assertIn("phone", errors)
-        self.assertEqual(errors["phone"], "Por favor ingrese un teléfono que solo contenga números")
+        self.assertEqual(errors["phone"], "Por favor ingrese un teléfono")
     
     def test_phone_number_without_54(self):
         vet_data = {
@@ -434,7 +434,7 @@ class VetModelTest(TestCase):
         }
         errors = validate_vet(vet_data)
         self.assertIn("phone", errors)
-        self.assertEqual(errors["phone"], "El número de teléfono debe comenzar con el prefijo 54 para Argentina.")
+        self.assertEqual(errors["phone"], "El número de teléfono debe comenzar con el prefijo 54 para Argentina")
 
         
 

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -93,7 +93,18 @@ class ClientModelTest(TestCase):
         errors = validate_client(client_data)
         self.assertIn("name", errors)
         self.assertEqual(errors["name"], "El nombre solo puede contener letras y espacios")
-    
+
+    def test_phone_number_blank(self):
+        client_data = {
+            "name": "Juan Sebastian Veron",
+            "phone": "",
+            "address": "13 y 44",
+            "email": "brujita75@vetsoft.com",
+        }
+        errors = validate_client(client_data)
+        self.assertIn("phone", errors)
+        self.assertEqual(errors["phone"], "Por favor ingrese un teléfono")
+
     def test_validate_name_with_valid_characters(self):
         client_data = {
             "name": "Juan Sebastian Veron",

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -70,7 +70,7 @@ class ClientModelTest(TestCase):
         
         errors = validate_client(client_data)
         self.assertIn("phone", errors)
-        self.assertEqual(errors["phone"], "Por favor ingrese un teléfono")
+        self.assertEqual(errors["phone"], "Por favor ingrese un teléfono que solo contenga números")
     
     def test_phone_number_without_54(self):
         client_data = {
@@ -423,7 +423,7 @@ class VetModelTest(TestCase):
         
         errors = validate_client(vet_data)
         self.assertIn("phone", errors)
-        self.assertEqual(errors["phone"], "Por favor ingrese un teléfono")
+        self.assertEqual(errors["phone"], "Por favor ingrese un teléfono que solo contenga números")
     
     def test_phone_number_without_54(self):
         vet_data = {

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -60,17 +60,17 @@ class ClientModelTest(TestCase):
 
         self.assertEqual(client_updated.phone, "54221555232")
     
-    def test_validate_phone_number_in_phone_field(self):
+    def test_validate_phone_number_with_letters(self):
         client_data = {
             "name": "Juan Sebastian Veron",
-            "phone": "",
+            "phone": "54221aaa221",
             "address": "13 y 44",
             "email": "brujita75@vetsoft.com",
         }
         
         errors = validate_client(client_data)
         self.assertIn("phone", errors)
-        self.assertEqual(errors["phone"], "Por favor ingrese un teléfono")
+        self.assertEqual(errors["phone"], "El número de teléfono debe comenzar con el prefijo 54 para Argentina y solo puede contener números")
     
     def test_phone_number_without_54(self):
         client_data = {

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -191,7 +191,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         self.page.get_by_role("button", name="Guardar").click()
 
         expect(self.page.get_by_text("Por favor ingrese un nombre")).to_be_visible()
-        expect(self.page.get_by_text("Por favor ingrese un teléfono que solo contenga números")).to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese un teléfono")).to_be_visible()
         expect(self.page.get_by_text("Por favor ingrese un email")).to_be_visible()
 
         self.page.get_by_label("Nombre").fill("Juan Sebastián Veron")
@@ -203,7 +203,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
 
         expect(self.page.get_by_text("Por favor ingrese un nombre")).not_to_be_visible()
         expect(
-            self.page.get_by_text("Por favor ingrese un teléfono que solo contenga números"),
+            self.page.get_by_text("Por favor ingrese un teléfono"),
         ).not_to_be_visible()
 
         expect(
@@ -219,7 +219,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         self.page.get_by_role("button", name="Guardar").click()
 
         expect(self.page.get_by_text("Por favor ingrese un nombre")).to_be_visible()
-        expect(self.page.get_by_text("Por favor ingrese un teléfono que solo contenga números")).to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese un teléfono")).to_be_visible()
         expect(self.page.get_by_text("Por favor ingrese un email")).to_be_visible()
 
         self.page.get_by_label("Nombre").fill("Nuria Molina")
@@ -230,7 +230,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         self.page.get_by_role("button", name="Guardar").click()
 
         expect(self.page.get_by_text("Por favor ingrese un nombre")).not_to_be_visible()
-        expect(self.page.get_by_text("Por favor ingrese un teléfono que solo contenga números")).to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese un teléfono")).to_be_visible()
         expect(self.page.get_by_text("Por favor ingrese un email válido")).not_to_be_visible()
         
         expect(self.page.get_by_text("El email debe terminar con @vetsoft.com")).to_be_visible()
@@ -281,7 +281,21 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
 
         self.page.get_by_role("button", name="Guardar").click()
 
-        expect(self.page.get_by_text("El número de teléfono debe comenzar con el prefijo 54 para Argentina.")).to_be_visible()
+        expect(self.page.get_by_text("El número de teléfono debe comenzar con el prefijo 54 para Argentina")).to_be_visible()
+
+    def test_should_view_errors_if_phone_has_letters(self):
+        self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
+
+        expect(self.page.get_by_role("form")).to_be_visible()
+
+        self.page.get_by_label("Nombre").fill("Juan Sebastian Veron")
+        self.page.get_by_label("Teléfono").fill("54221634soyunerror")
+        self.page.get_by_label("Email").fill("brujita75@vetsoft.com")
+        self.page.get_by_label("Dirección").fill("13 y 44")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(self.page.get_by_text("El número de teléfono debe comenzar con el prefijo 54 para Argentina y solo puede contener números")).to_be_visible()
 
 
 #  TEST DE PETS

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -191,7 +191,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         self.page.get_by_role("button", name="Guardar").click()
 
         expect(self.page.get_by_text("Por favor ingrese un nombre")).to_be_visible()
-        expect(self.page.get_by_text("Por favor ingrese un teléfono")).to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese un teléfono que solo contenga números")).to_be_visible()
         expect(self.page.get_by_text("Por favor ingrese un email")).to_be_visible()
 
         self.page.get_by_label("Nombre").fill("Juan Sebastián Veron")
@@ -203,7 +203,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
 
         expect(self.page.get_by_text("Por favor ingrese un nombre")).not_to_be_visible()
         expect(
-            self.page.get_by_text("Por favor ingrese un teléfono"),
+            self.page.get_by_text("Por favor ingrese un teléfono que solo contenga números"),
         ).not_to_be_visible()
 
         expect(
@@ -219,7 +219,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         self.page.get_by_role("button", name="Guardar").click()
 
         expect(self.page.get_by_text("Por favor ingrese un nombre")).to_be_visible()
-        expect(self.page.get_by_text("Por favor ingrese un teléfono")).to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese un teléfono que solo contenga números")).to_be_visible()
         expect(self.page.get_by_text("Por favor ingrese un email")).to_be_visible()
 
         self.page.get_by_label("Nombre").fill("Nuria Molina")
@@ -230,7 +230,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         self.page.get_by_role("button", name="Guardar").click()
 
         expect(self.page.get_by_text("Por favor ingrese un nombre")).not_to_be_visible()
-        expect(self.page.get_by_text("Por favor ingrese un teléfono")).to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese un teléfono que solo contenga números")).to_be_visible()
         expect(self.page.get_by_text("Por favor ingrese un email válido")).not_to_be_visible()
         
         expect(self.page.get_by_text("El email debe terminar con @vetsoft.com")).to_be_visible()


### PR DESCRIPTION
# Descripción del PR
- Se muestra el error de que el teléfono es inválido con letras
# Lista de cambios
- El formulario de teléfono de cliente pasa de tipo number a tipo text
- Se agregan nuevos patrones para validar el teléfono y nuevos mensajes de errores
- Se agrega el mensaje de error cuando aparecen letras en el teléfono y se pide que el input solo contenga números
- Se modifican los tests para que coincidan con los nuevos mensajes
- Se agrega test unitario, integración y e2e, donde se verifica que se muestre el mensaje de error en caso de que el input de número de teléfono contenga letras